### PR TITLE
Update dependencies to latest compatible versions

### DIFF
--- a/2/2-3/package.json
+++ b/2/2-3/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "gulpFile.js",
   "dependencies": {
-    "gulp": "^5.0.0"
+    "gulp": "^5.0.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/4/koaAPI/package.json
+++ b/4/koaAPI/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "koa": "^2.15.3"
+    "koa": "^2.16.3"
   },
   "devDependencies": {},
   "scripts": {

--- a/5/5-3/package.json
+++ b/5/5-3/package.json
@@ -5,9 +5,9 @@
   "main": "blueBirdDemo.js",
   "dependencies": {
     "bluebird": "^3.7.2",
-    "express": "^4.21.1",
-    "koa": "^2.15.3",
-    "sails": "^1.5.11"
+    "express": "^4.21.2",
+    "koa": "^2.16.3",
+    "sails": "^1.5.15"
   },
   "devDependencies": {},
   "scripts": {

--- a/5/5-3/sails/package.json
+++ b/5/5-3/sails/package.json
@@ -20,7 +20,7 @@
     "grunt-sync": "^0.8.2",
     "include-all": "^4.0.3",
     "rc": "^1.2.8",
-    "sails": "^1.5.11",
+    "sails": "^1.5.15",
     "sails-disk": "^2.1.2"
   },
   "scripts": {

--- a/5/5-4/package.json
+++ b/5/5-4/package.json
@@ -5,9 +5,9 @@
   "main": "blueBirdDemo.js",
   "dependencies": {
     "bluebird": "^3.7.2",
-    "express": "^4.21.1",
-    "koa": "^2.15.3",
-    "sails": "^1.5.11"
+    "express": "^4.21.2",
+    "koa": "^2.16.3",
+    "sails": "^1.5.15"
   },
   "devDependencies": {},
   "scripts": {

--- a/5/5-4/sails/package.json
+++ b/5/5-4/sails/package.json
@@ -20,7 +20,7 @@
     "grunt-sync": "^0.8.2",
     "include-all": "^4.0.3",
     "rc": "^1.2.8",
-    "sails": "^1.5.11",
+    "sails": "^1.5.15",
     "sails-disk": "^2.1.2"
   },
   "scripts": {


### PR DESCRIPTION
- Update koa from 2.15.3 to 2.16.3
- Update express from 4.21.1 to 4.21.2
- Update sails from 1.5.11 to 1.5.15
- Update gulp from 5.0.0 to 5.0.1

These updates include bug fixes and minor improvements while maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)